### PR TITLE
Allow swappable models to change "max_length_factor" at runtime.

### DIFF
--- a/src/translator/beam_search.cpp
+++ b/src/translator/beam_search.cpp
@@ -248,7 +248,10 @@ Beams BeamSearch::purgeBeams(const Beams& beams, /*in/out=*/std::vector<IndexTyp
 
 //**********************************************************************
 // main decoding function
-Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> batch) {
+Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> batch, float max_length_factor) {
+  if (max_length_factor < 0)
+    max_length_factor = options_->get<float>("max-length-factor");
+
   auto factoredVocab = trgVocab_->tryAs<FactoredVocab>();
   size_t numFactorGroups = factoredVocab ? factoredVocab->getNumGroups() : 1;
   if (numFactorGroups == 1) // if no factors then we didn't need this object in the first place
@@ -503,7 +506,7 @@ Histories BeamSearch::search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> 
     for(int batchIdx = 0; batchIdx < origDimBatch; ++batchIdx) {
       // if this batch entry has surviving hyps then add them to the traceback grid
       if(!beams[batchIdx].empty()) { // if the beam is not empty expand the history object associated with the beam
-        if (histories[batchIdx]->size() >= options_->get<float>("max-length-factor") * batch->front()->batchWidth())
+        if (histories[batchIdx]->size() >= max_length_factor * batch->front()->batchWidth())
           maxLengthReached = true;
         histories[batchIdx]->add(beams[batchIdx], trgEosId, purgedNewBeams[batchIdx].empty() || maxLengthReached);
       }

--- a/src/translator/beam_search.h
+++ b/src/translator/beam_search.h
@@ -52,7 +52,7 @@ public:
   Beams purgeBeams(const Beams& beams, /*in/out=*/std::vector<IndexType>& batchIdxMap);
 
   // main decoding function
-  Histories search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> batch);
+  Histories search(Ptr<ExpressionGraph> graph, Ptr<data::CorpusBatch> batch, float max_length_factor = -1.f);
 };
 
 }  // namespace marian

--- a/src/translator/swappable.cpp
+++ b/src/translator/swappable.cpp
@@ -100,7 +100,7 @@ std::string MultilineInputHack(const std::vector<std::string> &input) {
   }
 }
 
-Histories GPULoadedModel::Translate(const std::vector<std::string> &input) {
+Histories GPULoadedModel::Translate(const std::vector<std::string> &input, float max_length_factor) {
   ABORT_IF(!trgVocab_, "GPULoadedModel needs to be overwritten by a CPU model first.");
   engine_->SwapPointers(parameters_);
 
@@ -111,7 +111,7 @@ Histories GPULoadedModel::Translate(const std::vector<std::string> &input) {
   Histories ret;
   ret.reserve(input.size());
   for (auto&& batch : batchGenerator) {
-    auto result = search.search(engine_->graph_, batch);
+    auto result = search.search(engine_->graph_, batch, max_length_factor);
     ret.insert(ret.end(), result.begin(), result.end());
   }
   std::sort(ret.begin(), ret.end(),[](marian::Ptr<marian::History> a, marian::Ptr<marian::History> b){return a->getLineNum() < b->getLineNum();});

--- a/src/translator/swappable.h
+++ b/src/translator/swappable.h
@@ -64,7 +64,7 @@ class GPULoadedModel {
     void Load(const CPULoadedModel &from);
     void Load(const GPULoadedModel &from);
 
-    Histories Translate(const std::vector<std::string> &input);
+    Histories Translate(const std::vector<std::string> &input, float max_length_factor = -1.f);
 };
 
 /* A model loaded on the CPU. */


### PR DESCRIPTION
The source-to-target length ratio depends on the language combination used.
This pull request adds an optional parameter to BeamSearch::search() in order to override the default value specified in command-line options.

This change is totally **backward compatible**: if the optional parameter is not specified, BeamSearch fallbacks to the one provided in the options object.